### PR TITLE
smee: don't drop messages

### DIFF
--- a/src/smee_client.rs
+++ b/src/smee_client.rs
@@ -2,7 +2,7 @@ use crate::github::{Event, EventType, Webhook};
 use bytes::{Buf, BytesMut};
 use hyper::{body::HttpBody, Body, Client, Request};
 use hyper_tls::HttpsConnector;
-use log::{debug, info};
+use log::info;
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use std::borrow::Cow;
@@ -64,7 +64,7 @@ enum SmeeEvent {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SmeeMessage<'a> {
+struct SmeeMessage<'a> {
     #[serde(rename = "x-github-event")]
     event_type: EventType,
     #[serde(borrow, rename = "body")]
@@ -73,6 +73,11 @@ pub struct SmeeMessage<'a> {
     guid: String,
     #[serde(rename = "x-hub-signature")]
     signature: Option<String>,
+}
+
+struct ServerSentEvent<'a> {
+    event: Option<&'a str>,
+    data: Option<Cow<'a, str>>,
 }
 
 struct SmeeEventParser<'b> {
@@ -89,17 +94,10 @@ impl<'b> SmeeEventParser<'b> {
     }
 
     async fn next(&mut self) -> Result<Option<SmeeEvent>, SmeeError> {
-        while let Some(data) = self.body.data().await {
-            let data = data?;
-            debug!("bytes = {:?}", data.bytes());
-            self.buffer.extend_from_slice(data.bytes());
-            if !self.contains_end_of_event() {
-                debug!("message isn't ended, reading more");
-                continue;
-            }
+        while let Some(raw_event) = self.next_server_sent_event().await? {
+            let server_sent_event = Self::parse_server_sent_event(&raw_event)?;
 
-            debug!("got whole message");
-            if let Some(event) = Self::parse_smee_event(&self.buffer.split())? {
+            if let Some(event) = Self::parse_smee_event(server_sent_event)? {
                 return Ok(Some(event));
             }
         }
@@ -107,39 +105,53 @@ impl<'b> SmeeEventParser<'b> {
         Ok(None)
     }
 
-    fn parse_smee_event(raw_event: &[u8]) -> Result<Option<SmeeEvent>, SmeeError> {
-        let mut smee_event_type = None;
+    /// Contiune polling data off of the stream, splitting off and returning every time a complete
+    /// Event is found
+    async fn next_server_sent_event(&mut self) -> Result<Option<BytesMut>, SmeeError> {
+        loop {
+            if let Some(idx) = self.find_end_of_event() {
+                return Ok(Some(self.buffer.split_to(idx)));
+            }
+
+            if let Some(data) = self.body.data().await {
+                let data = data?;
+                self.buffer.extend_from_slice(data.bytes());
+            } else {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn parse_smee_event(
+        server_sent_event: ServerSentEvent<'_>,
+    ) -> Result<Option<SmeeEvent>, SmeeError> {
+        let event = match (server_sent_event.event, server_sent_event.data) {
+            (Some("ready"), Some(_)) => SmeeEvent::Ready,
+            (Some("ping"), Some(_)) => SmeeEvent::Ping,
+            (None, Some(data)) => {
+                let smee_msg: SmeeMessage = serde_json::from_str(&data)?;
+                let event =
+                    Event::from_json(&smee_msg.event_type, smee_msg.event.get().as_bytes())?;
+                let webhook = Webhook {
+                    event_type: smee_msg.event_type,
+                    event,
+                    guid: smee_msg.guid,
+                    signature: smee_msg.signature,
+                    body: None,
+                };
+                SmeeEvent::Message(webhook)
+            }
+            _ => return Ok(None),
+        };
+
+        Ok(Some(event))
+    }
+
+    fn parse_server_sent_event(raw_event: &[u8]) -> Result<ServerSentEvent<'_>, SmeeError> {
+        let mut event = None;
         let mut data: Option<Cow<'_, str>> = None;
 
         for line in str::from_utf8(raw_event)?.lines() {
-            debug!("line = {}", line);
-
-            // dispatch event if blank line
-            if line.is_empty() {
-                let event = match (smee_event_type.take(), data.take()) {
-                    (Some("ready"), Some(_)) => Some(SmeeEvent::Ready),
-                    (Some("ping"), Some(_)) => Some(SmeeEvent::Ping),
-                    (None, Some(data)) => {
-                        let smee_msg: SmeeMessage = serde_json::from_str(&data)?;
-                        let event = Event::from_json(
-                            &smee_msg.event_type,
-                            smee_msg.event.get().as_bytes(),
-                        )?;
-                        let webhook = Webhook {
-                            event_type: smee_msg.event_type,
-                            event,
-                            guid: smee_msg.guid,
-                            signature: smee_msg.signature,
-                            body: None,
-                        };
-                        Some(SmeeEvent::Message(webhook))
-                    }
-                    _ => continue,
-                };
-
-                return Ok(event);
-            }
-
             // skip comments
             if line.starts_with(':') {
                 continue;
@@ -163,7 +175,7 @@ impl<'b> SmeeEventParser<'b> {
             match field {
                 "event" => {
                     if let Some(value) = value {
-                        smee_event_type = Some(value);
+                        event = Some(value);
                     }
                 }
 
@@ -183,15 +195,19 @@ impl<'b> SmeeEventParser<'b> {
             }
         }
 
-        Ok(None)
+        Ok(ServerSentEvent { event, data })
     }
 
-    fn contains_end_of_event(&self) -> bool {
-        let length = self.buffer.len();
-        debug!("contains: length = {}", length);
-        debug!("eob = {:?}", &self.buffer[length - 4..]);
-        (length >= 2 && &self.buffer[length - 2..] == b"\n\n")
-            || (length >= 2 && &self.buffer[length - 2..] == b"\r\r")
-            || (length >= 4 && &self.buffer[length - 4..] == b"\r\n\r\n")
+    fn find_end_of_event(&self) -> Option<usize> {
+        fn find_end_of_subsequence(buffer: &[u8], pattern: &[u8]) -> Option<usize> {
+            buffer
+                .windows(pattern.len())
+                .position(|window| window == pattern)
+                .map(|idx| idx + pattern.len())
+        }
+
+        find_end_of_subsequence(&self.buffer, b"\n\n")
+            .or_else(|| find_end_of_subsequence(&self.buffer, b"\r\r"))
+            .or_else(|| find_end_of_subsequence(&self.buffer, b"\r\n\r\n"))
     }
 }


### PR DESCRIPTION
This patch fixes an issue where if a http chunk is received and it
contains multiple Server-Sent Events only the first event is processed
and the remainder are thrown away.